### PR TITLE
Unescape all characters by default

### DIFF
--- a/runtime/mux.go
+++ b/runtime/mux.go
@@ -13,6 +13,31 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// UnescapingMode defines the behavior of ServeMux when unescaping path parameters.
+type UnescapingMode int
+
+const (
+	// UnescapingModeLegacy is the default V2 behavior, which escapes the entire
+	// path string before doing any routing.
+	UnescapingModeLegacy UnescapingMode = iota
+
+	// UnescapingModeAllExceptReserved unescapes all path parameters except RFC 6570
+	// reserved characters.
+	UnescapingModeAllExceptReserved
+
+	// UnescapingModeAllExceptSlash unescapes URL path parameters except path
+	// separators, which will be left as "%2F".
+	UnescapingModeAllExceptSlash
+
+	// UnescapingModeAllCharacters unescapes all URL path parameters.
+	UnescapingModeAllCharacters
+
+	// UnescapingModeDefault is the default escaping type.
+	// TODO(v3): default this to UnescapingModeAllExceptReserved per grpc-httpjson-transcoding's
+	// reference implementation
+	UnescapingModeDefault = UnescapingModeLegacy
+)
+
 // A HandlerFunc handles a specific pair of path pattern and HTTP method.
 type HandlerFunc func(w http.ResponseWriter, r *http.Request, pathParams map[string]string)
 

--- a/runtime/pattern.go
+++ b/runtime/pattern.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/grpc-ecosystem/grpc-gateway/utilities"
@@ -14,7 +15,15 @@ var (
 	ErrNotMatch = errors.New("not match to the path pattern")
 	// ErrInvalidPattern indicates that the given definition of Pattern is not valid.
 	ErrInvalidPattern = errors.New("invalid pattern")
+	// ErrMalformedSequence indicates that an escape sequence was malformed.
+	ErrMalformedSequence = errors.New("malformed escape sequence")
 )
+
+type MalformedSequenceError string
+
+func (e MalformedSequenceError) Error() string {
+	return "malformed path escape " + strconv.Quote(string(e))
+}
 
 type op struct {
 	code    utilities.OpCode
@@ -157,12 +166,13 @@ func MustPattern(p Pattern, err error) Pattern {
 	return p
 }
 
-// Match examines components if it matches to the Pattern.
-// If it matches, the function returns a mapping from field paths to their captured values.
-// If otherwise, the function returns an error.
-func (p Pattern) Match(components []string, verb string) (map[string]string, error) {
+// MatchAndEscape examines components to determine if they match to a Pattern.
+// MatchAndEscape will return an error if no Patterns matched or if a pattern
+// matched but contained malformed escape sequences. If successful, the function
+// returns a mapping from field paths to their captured values.
+func (p Pattern) MatchAndEscape(components []string, verb string, unescapingMode UnescapingMode) (map[string]string, error) {
 	if p.verb != verb {
-		if p.assumeColonVerb || p.verb != "" {
+		if p.verb != "" {
 			return nil, ErrNotMatch
 		}
 		if len(components) == 0 {
@@ -171,7 +181,6 @@ func (p Pattern) Match(components []string, verb string) (map[string]string, err
 			components = append([]string{}, components...)
 			components[len(components)-1] += ":" + verb
 		}
-		verb = ""
 	}
 
 	var pos int
@@ -179,6 +188,8 @@ func (p Pattern) Match(components []string, verb string) (map[string]string, err
 	captured := make([]string, len(p.vars))
 	l := len(components)
 	for _, op := range p.ops {
+		var err error
+
 		switch op.code {
 		case utilities.OpNop:
 			continue
@@ -191,6 +202,10 @@ func (p Pattern) Match(components []string, verb string) (map[string]string, err
 				if lit := p.pool[op.operand]; c != lit {
 					return nil, ErrNotMatch
 				}
+			} else if op.code == utilities.OpPush {
+				if c, err = unescape(c, unescapingMode, false); err != nil {
+					return nil, err
+				}
 			}
 			stack = append(stack, c)
 			pos++
@@ -200,7 +215,11 @@ func (p Pattern) Match(components []string, verb string) (map[string]string, err
 				return nil, ErrNotMatch
 			}
 			end -= p.tailLen
-			stack = append(stack, strings.Join(components[pos:end], "/"))
+			c := strings.Join(components[pos:end], "/")
+			if c, err = unescape(c, unescapingMode, true); err != nil {
+				return nil, err
+			}
+			stack = append(stack, c)
 			pos = end
 		case utilities.OpConcatN:
 			n := op.operand
@@ -220,6 +239,16 @@ func (p Pattern) Match(components []string, verb string) (map[string]string, err
 		bindings[p.vars[i]] = val
 	}
 	return bindings, nil
+}
+
+// MatchAndEscape examines components to determine if they match to a Pattern.
+// It will never perform per-component unescaping (see: UnescapingModeLegacy).
+// MatchAndEscape will return an error if no Patterns matched. If successful,
+// the function returns a mapping from field paths to their captured values.
+//
+// Deprecated: Use MatchAndEscape.
+func (p Pattern) Match(components []string, verb string) (map[string]string, error) {
+	return p.MatchAndEscape(components, verb, UnescapingModeAllCharacters)
 }
 
 // Verb returns the verb part of the Pattern.
@@ -259,4 +288,112 @@ func AssumeColonVerbOpt(val bool) PatternOpt {
 	return PatternOpt(func(o *patternOptions) {
 		o.assumeColonVerb = val
 	})
+}
+
+// ishex returns whether or not the given byte is a valid hex character
+func ishex(c byte) bool {
+	switch {
+	case '0' <= c && c <= '9':
+		return true
+	case 'a' <= c && c <= 'f':
+		return true
+	case 'A' <= c && c <= 'F':
+		return true
+	}
+	return false
+}
+
+func isRFC6570Reserved(c byte) bool {
+	switch c {
+	case '!', '#', '$', '&', '\'', '(', ')', '*',
+		'+', ',', '/', ':', ';', '=', '?', '@', '[', ']':
+		return true
+	default:
+		return false
+	}
+}
+
+// unhex converts a hex point to the bit representation
+func unhex(c byte) byte {
+	switch {
+	case '0' <= c && c <= '9':
+		return c - '0'
+	case 'a' <= c && c <= 'f':
+		return c - 'a' + 10
+	case 'A' <= c && c <= 'F':
+		return c - 'A' + 10
+	}
+	return 0
+}
+
+// shouldUnescapeWithMode returns true if the character is escapable with the
+// given mode
+func shouldUnescapeWithMode(c byte, mode UnescapingMode) bool {
+	switch mode {
+	case UnescapingModeAllExceptReserved:
+		if isRFC6570Reserved(c) {
+			return false
+		}
+	case UnescapingModeAllExceptSlash:
+		if c == '/' {
+			return false
+		}
+	case UnescapingModeAllCharacters:
+		return true
+	}
+	return true
+}
+
+// unescape unescapes a path string using the provided mode
+func unescape(s string, mode UnescapingMode, multisegment bool) (string, error) {
+	// TODO(v3): remove UnescapingModeLegacy
+	if mode == UnescapingModeLegacy {
+		return s, nil
+	}
+
+	if !multisegment {
+		mode = UnescapingModeAllCharacters
+	}
+
+	// Count %, check that they're well-formed.
+	n := 0
+	for i := 0; i < len(s); {
+		if s[i] == '%' {
+			n++
+			if i+2 >= len(s) || !ishex(s[i+1]) || !ishex(s[i+2]) {
+				s = s[i:]
+				if len(s) > 3 {
+					s = s[:3]
+				}
+
+				return "", MalformedSequenceError(s)
+			}
+			i += 3
+		} else {
+			i++
+		}
+	}
+
+	if n == 0 {
+		return s, nil
+	}
+
+	var t strings.Builder
+	t.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '%':
+			c := unhex(s[i+1])<<4 | unhex(s[i+2])
+			if shouldUnescapeWithMode(c, mode) {
+				t.WriteByte(c)
+				i += 2
+				continue
+			}
+			fallthrough
+		default:
+			t.WriteByte(s[i])
+		}
+	}
+
+	return t.String(), nil
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Starts unescaping all characters such as `%2F` -> `/`

more context:
https://github.com/grpc-ecosystem/grpc-gateway/issues/2629
https://github.com/sveltejs/kit/issues/3069

## Why?
<!-- Tell your future self why have you made these changes -->

Address https://github.com/temporalio/ui/issues/392


## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

verified using canary data
![image](https://user-images.githubusercontent.com/11838981/162870832-c7e2a9d5-88e4-4e07-9549-5317278b9222.png)

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
